### PR TITLE
Downgrading to v1 to get tokensale API endpoint working

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,12 +1,6 @@
 {
-  "version": 2,
-  "builds": [
-    { "src": "mybit/index.js", "use": "@now/node-server" },
-    { "src": "mybit-go/index.js", "use": "@now/node-server" },
-    { "src": "version/index.js", "use": "@now/node-server" },
-    { "src": "token-sale/index.js", "use": "@now/node-server" }
-  ], 
+  "version": 1,
   "env": {
-	"INFURA_API_KEY": "@infura-api-key"
+    "INFURA_API_KEY": "@infura-api-key"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start:mybit": "node mybit/index.js",
     "start:mybit-go": "node mybit-go/index.js",
     "start:token-sale": "node token-sale/index.js",
-    "start:version": "node version/index.js"
+    "start:version": "node version/index.js",
+    "now-start": "node token-sale/index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Unfortunately, that disables our other endpoints but we aren't using them. This is due to an issue with now.sh they are solving in https://github.com/zeit/now-builders/issues/49.